### PR TITLE
KTB-16 Add Telegram inline buttons

### DIFF
--- a/src/main/kotlin/Telegram.kt
+++ b/src/main/kotlin/Telegram.kt
@@ -1,5 +1,6 @@
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.net.URI
 import java.net.URLEncoder
@@ -10,6 +11,9 @@ import java.nio.charset.StandardCharsets
 
 const val TELEGRAM_BASE_URL = "https://api.telegram.org"
 const val TELEGRAM_MESSAGE_MAX_LENGTH = 4096
+const val TELEGRAM_CALLBACK_DATA_MAX_BYTES = 64
+const val CALLBACK_LEARN_WORDS = "learn_words"
+const val CALLBACK_STATISTICS = "statistics"
 
 private val telegramHttpClient: HttpClient = HttpClient.newHttpClient()
 private val telegramJson = Json { ignoreUnknownKeys = true }
@@ -25,6 +29,8 @@ data class TelegramUpdate(
     @SerialName("update_id")
     val updateId: Long,
     val message: TelegramMessage? = null,
+    @SerialName("callback_query")
+    val callbackQuery: TelegramCallbackQuery? = null,
 )
 
 @Serializable
@@ -36,6 +42,46 @@ data class TelegramMessage(
 @Serializable
 data class TelegramChat(
     val id: Long,
+)
+
+@Serializable
+data class TelegramCallbackQuery(
+    val id: String,
+    val message: TelegramMessage? = null,
+    val data: String? = null,
+)
+
+@Serializable
+data class InlineKeyboardButton(
+    val text: String,
+    @SerialName("callback_data")
+    val callbackData: String,
+) {
+    init {
+        require(text.isNotBlank()) { "Текст кнопки не должен быть пустым." }
+        require(callbackData.toByteArray(StandardCharsets.UTF_8).size in 1..TELEGRAM_CALLBACK_DATA_MAX_BYTES) {
+            "Длина callback_data должна быть от 1 до $TELEGRAM_CALLBACK_DATA_MAX_BYTES байт."
+        }
+    }
+}
+
+@Serializable
+data class InlineKeyboardMarkup(
+    @SerialName("inline_keyboard")
+    val inlineKeyboard: List<List<InlineKeyboardButton>>,
+) {
+    init {
+        require(inlineKeyboard.isNotEmpty() && inlineKeyboard.all { it.isNotEmpty() }) {
+            "Клавиатура должна содержать хотя бы одну кнопку."
+        }
+    }
+}
+
+val mainMenuKeyboard = InlineKeyboardMarkup(
+    inlineKeyboard = listOf(
+        listOf(InlineKeyboardButton("Учить слова", CALLBACK_LEARN_WORDS)),
+        listOf(InlineKeyboardButton("Статистика", CALLBACK_STATISTICS)),
+    ),
 )
 
 fun main(args: Array<String>) {
@@ -50,10 +96,7 @@ fun main(args: Array<String>) {
         val updates = parseUpdates(getUpdates(botToken, updateId))
 
         updates.result.forEach { update ->
-            val message = update.message
-            if (message?.text != null) {
-                sendMessage(botToken, message.chat.id, message.text)
-            }
+            handleUpdate(botToken, update)
         }
 
         updateId = updates.result.maxOfOrNull { it.updateId + 1 } ?: updateId
@@ -70,24 +113,80 @@ fun getUpdates(botToken: String, updateId: Long): String {
     return responseUpdates.body()
 }
 
-fun sendMessage(botToken: String, chatId: Long, text: String): String {
-    val request = createSendMessageRequest(botToken, chatId, text)
+fun handleUpdate(
+    botToken: String,
+    update: TelegramUpdate,
+    messageSender: (String, Long, String, InlineKeyboardMarkup?) -> String = ::sendMessage,
+    callbackAnswerer: (String, String) -> String = ::answerCallbackQuery,
+) {
+    if (update.message?.text != null) {
+        messageSender(botToken, update.message.chat.id, "Выберите действие:", mainMenuKeyboard)
+    }
+
+    update.callbackQuery?.let { callback ->
+        callbackAnswerer(botToken, callback.id)
+        val chatId = callback.message?.chat?.id ?: return@let
+        val responseText = when (callback.data) {
+            CALLBACK_LEARN_WORDS -> "Начинаем учить слова."
+            CALLBACK_STATISTICS -> "Показываю статистику."
+            else -> "Неизвестная команда."
+        }
+        messageSender(botToken, chatId, responseText, mainMenuKeyboard)
+    }
+}
+
+fun sendMessage(
+    botToken: String,
+    chatId: Long,
+    text: String,
+    replyMarkup: InlineKeyboardMarkup? = null,
+): String {
+    val request = createSendMessageRequest(botToken, chatId, text, replyMarkup)
     val response = telegramHttpClient.send(request, HttpResponse.BodyHandlers.ofString())
     return response.body()
 }
 
-fun createSendMessageRequest(botToken: String, chatId: Long, text: String): HttpRequest {
+fun createSendMessageRequest(
+    botToken: String,
+    chatId: Long,
+    text: String,
+    replyMarkup: InlineKeyboardMarkup? = null,
+): HttpRequest {
     require(botToken.isNotBlank()) { "Токен Telegram-бота не должен быть пустым." }
     val textLength = text.codePointCount(0, text.length)
     require(textLength in 1..TELEGRAM_MESSAGE_MAX_LENGTH) {
         "Длина сообщения должна быть от 1 до $TELEGRAM_MESSAGE_MAX_LENGTH символов."
     }
 
-    val requestBody = "chat_id=$chatId&text=${urlEncode(text)}"
+    val parameters = mutableListOf(
+        "chat_id=$chatId",
+        "text=${urlEncode(text)}",
+    )
+    if (replyMarkup != null) {
+        parameters += "reply_markup=${urlEncode(telegramJson.encodeToString(replyMarkup))}"
+    }
+
     return HttpRequest.newBuilder()
         .uri(URI.create("$TELEGRAM_BASE_URL/bot$botToken/sendMessage"))
         .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
-        .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+        .POST(HttpRequest.BodyPublishers.ofString(parameters.joinToString("&")))
+        .build()
+}
+
+fun answerCallbackQuery(botToken: String, callbackQueryId: String): String {
+    val request = createAnswerCallbackQueryRequest(botToken, callbackQueryId)
+    val response = telegramHttpClient.send(request, HttpResponse.BodyHandlers.ofString())
+    return response.body()
+}
+
+fun createAnswerCallbackQueryRequest(botToken: String, callbackQueryId: String): HttpRequest {
+    require(botToken.isNotBlank()) { "Токен Telegram-бота не должен быть пустым." }
+    require(callbackQueryId.isNotBlank()) { "Идентификатор callback-запроса не должен быть пустым." }
+
+    return HttpRequest.newBuilder()
+        .uri(URI.create("$TELEGRAM_BASE_URL/bot$botToken/answerCallbackQuery"))
+        .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+        .POST(HttpRequest.BodyPublishers.ofString("callback_query_id=${urlEncode(callbackQueryId)}"))
         .build()
 }
 

--- a/src/test/kotlin/TelegramTest.kt
+++ b/src/test/kotlin/TelegramTest.kt
@@ -1,11 +1,14 @@
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.ByteBuffer
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.Flow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TelegramTest {
     @Test
@@ -65,6 +68,91 @@ class TelegramTest {
     }
 
     @Test
+    fun `callback query is parsed with source chat and callback data`() {
+        val response = parseUpdates(
+            """
+            {
+              "ok": true,
+              "result": [
+                {
+                  "update_id": 30,
+                  "callback_query": {
+                    "id": "callback-123",
+                    "data": "learn_words",
+                    "message": {
+                      "chat": {"id": 777},
+                      "text": "Выберите действие:"
+                    }
+                  }
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        val callback = response.result.single().callbackQuery
+        assertEquals("callback-123", callback?.id)
+        assertEquals(CALLBACK_LEARN_WORDS, callback?.data)
+        assertEquals(777L, callback?.message?.chat?.id)
+    }
+
+    @Test
+    fun `callback is acknowledged and response is sent to source chat`() {
+        val sentMessages = mutableListOf<Triple<Long, String, InlineKeyboardMarkup?>>()
+        val answeredCallbacks = mutableListOf<String>()
+        val update = TelegramUpdate(
+            updateId = 31,
+            callbackQuery = TelegramCallbackQuery(
+                id = "callback-31",
+                data = CALLBACK_STATISTICS,
+                message = TelegramMessage(TelegramChat(888), "Выберите действие:"),
+            ),
+        )
+
+        handleUpdate(
+            botToken = "token",
+            update = update,
+            messageSender = { _, chatId, text, keyboard ->
+                sentMessages += Triple(chatId, text, keyboard)
+                "{}"
+            },
+            callbackAnswerer = { _, callbackId ->
+                answeredCallbacks += callbackId
+                "true"
+            },
+        )
+
+        assertEquals(listOf("callback-31"), answeredCallbacks)
+        assertEquals(1, sentMessages.size)
+        assertEquals(888L, sentMessages.single().first)
+        assertEquals("Показываю статистику.", sentMessages.single().second)
+        assertEquals(mainMenuKeyboard, sentMessages.single().third)
+    }
+
+    @Test
+    fun `text message receives menu keyboard in its own chat`() {
+        val sentMessages = mutableListOf<Triple<Long, String, InlineKeyboardMarkup?>>()
+        val update = TelegramUpdate(
+            updateId = 32,
+            message = TelegramMessage(TelegramChat(-999), "/start"),
+        )
+
+        handleUpdate(
+            botToken = "token",
+            update = update,
+            messageSender = { _, chatId, text, keyboard ->
+                sentMessages += Triple(chatId, text, keyboard)
+                "{}"
+            },
+        )
+
+        assertEquals(1, sentMessages.size)
+        assertEquals(-999L, sentMessages.single().first)
+        assertEquals("Выберите действие:", sentMessages.single().second)
+        assertEquals(mainMenuKeyboard, sentMessages.single().third)
+    }
+
+    @Test
     fun `send message request uses post and encodes text`() {
         val request = createSendMessageRequest("token", -123, "Привет & hello")
 
@@ -95,6 +183,60 @@ class TelegramTest {
 
         createSendMessageRequest("token", 1, text)
     }
+
+    @Test
+    fun `send message request serializes inline keyboard as reply markup`() {
+        val request = createSendMessageRequest("token", 123, "Меню", mainMenuKeyboard)
+        val parameters = parseFormBody(readBody(request))
+
+        assertEquals("123", parameters["chat_id"])
+        assertEquals("Меню", parameters["text"])
+        assertEquals(
+            """{"inline_keyboard":[[{"text":"Учить слова","callback_data":"learn_words"}],[{"text":"Статистика","callback_data":"statistics"}]]}""",
+            parameters["reply_markup"],
+        )
+    }
+
+    @Test
+    fun `callback data must fit telegram byte limit`() {
+        InlineKeyboardButton("Кнопка", "a".repeat(TELEGRAM_CALLBACK_DATA_MAX_BYTES))
+
+        assertFailsWith<IllegalArgumentException> {
+            InlineKeyboardButton("Кнопка", "я".repeat(TELEGRAM_CALLBACK_DATA_MAX_BYTES))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            InlineKeyboardButton("Кнопка", "")
+        }
+    }
+
+    @Test
+    fun `answer callback query request uses callback id`() {
+        val request = createAnswerCallbackQueryRequest("token", "callback & 1")
+
+        assertEquals("POST", request.method())
+        assertEquals(
+            "https://api.telegram.org/bottoken/answerCallbackQuery",
+            request.uri().toString(),
+        )
+        assertEquals("callback_query_id=callback+%26+1", readBody(request))
+    }
+
+    @Test
+    fun `inline keyboard requires at least one button`() {
+        assertFailsWith<IllegalArgumentException> {
+            InlineKeyboardMarkup(emptyList())
+        }
+        assertFailsWith<IllegalArgumentException> {
+            InlineKeyboardMarkup(listOf(emptyList()))
+        }
+        assertTrue(mainMenuKeyboard.inlineKeyboard.flatten().isNotEmpty())
+    }
+
+    private fun parseFormBody(body: String): Map<String, String> =
+        body.split("&").associate { parameter ->
+            val (name, value) = parameter.split("=", limit = 2)
+            name to URLDecoder.decode(value, StandardCharsets.UTF_8)
+        }
 
     private fun readBody(request: HttpRequest): String {
         val bodyPublisher = request.bodyPublisher().orElseThrow()


### PR DESCRIPTION
## Изменения
- добавлены модели InlineKeyboardButton и InlineKeyboardMarkup
- кнопки сериализуются в JSON и отправляются через reply_markup метода sendMessage
- добавлено меню с кнопками «Учить слова» и «Статистика»
- реализован разбор callback_query и отправка ответа в исходный чат
- callback подтверждается методом answerCallbackQuery
- добавлена валидация callback_data по лимиту Telegram 1–64 байта

## Проверка
- 18 тестов успешно пройдены
- Gradle build successful на Java 19