### PR TITLE
KTB-17 Show trainer statistics in Telegram

### DIFF
--- a/src/main/kotlin/Telegram.kt
+++ b/src/main/kotlin/Telegram.kt
@@ -90,13 +90,14 @@ fun main(args: Array<String>) {
     }
 
     val botToken = args[0]
+    val trainer = LearnWordsTrainer()
     var updateId = 0L
     while (true) {
         Thread.sleep(3000)
         val updates = parseUpdates(getUpdates(botToken, updateId))
 
         updates.result.forEach { update ->
-            handleUpdate(botToken, update)
+            handleUpdate(botToken, update, trainer)
         }
 
         updateId = updates.result.maxOfOrNull { it.updateId + 1 } ?: updateId
@@ -116,6 +117,7 @@ fun getUpdates(botToken: String, updateId: Long): String {
 fun handleUpdate(
     botToken: String,
     update: TelegramUpdate,
+    trainer: LearnWordsTrainer,
     messageSender: (String, Long, String, InlineKeyboardMarkup?) -> String = ::sendMessage,
     callbackAnswerer: (String, String) -> String = ::answerCallbackQuery,
 ) {
@@ -128,12 +130,19 @@ fun handleUpdate(
         val chatId = callback.message?.chat?.id ?: return@let
         val responseText = when (callback.data) {
             CALLBACK_LEARN_WORDS -> "Начинаем учить слова."
-            CALLBACK_STATISTICS -> "Показываю статистику."
+            CALLBACK_STATISTICS -> formatStatistics(trainer.getStatistics())
             else -> "Неизвестная команда."
         }
         messageSender(botToken, chatId, responseText, mainMenuKeyboard)
     }
 }
+
+fun formatStatistics(statistics: Statistics): String =
+    if (statistics.totalWords == 0) {
+        "Словарь пуст."
+    } else {
+        "Выучено ${statistics.learnedWords} из ${statistics.totalWords} слов | ${statistics.learnedPercent}%"
+    }
 
 fun sendMessage(
     botToken: String,

--- a/src/test/kotlin/TelegramTest.kt
+++ b/src/test/kotlin/TelegramTest.kt
@@ -108,10 +108,18 @@ class TelegramTest {
                 message = TelegramMessage(TelegramChat(888), "Выберите действие:"),
             ),
         )
+        val trainer = createTrainer(
+            """
+            cat|кошка|3
+            dog|собака|0
+            house|дом|3
+            """.trimIndent(),
+        )
 
         handleUpdate(
             botToken = "token",
             update = update,
+            trainer = trainer,
             messageSender = { _, chatId, text, keyboard ->
                 sentMessages += Triple(chatId, text, keyboard)
                 "{}"
@@ -125,7 +133,7 @@ class TelegramTest {
         assertEquals(listOf("callback-31"), answeredCallbacks)
         assertEquals(1, sentMessages.size)
         assertEquals(888L, sentMessages.single().first)
-        assertEquals("Показываю статистику.", sentMessages.single().second)
+        assertEquals("Выучено 2 из 3 слов | 66%", sentMessages.single().second)
         assertEquals(mainMenuKeyboard, sentMessages.single().third)
     }
 
@@ -136,10 +144,12 @@ class TelegramTest {
             updateId = 32,
             message = TelegramMessage(TelegramChat(-999), "/start"),
         )
+        val trainer = createTrainer("cat|кошка|0")
 
         handleUpdate(
             botToken = "token",
             update = update,
+            trainer = trainer,
             messageSender = { _, chatId, text, keyboard ->
                 sentMessages += Triple(chatId, text, keyboard)
                 "{}"
@@ -150,6 +160,14 @@ class TelegramTest {
         assertEquals(-999L, sentMessages.single().first)
         assertEquals("Выберите действие:", sentMessages.single().second)
         assertEquals(mainMenuKeyboard, sentMessages.single().third)
+    }
+
+    @Test
+    fun `empty dictionary statistics are formatted for telegram`() {
+        assertEquals(
+            "Словарь пуст.",
+            formatStatistics(Statistics(learnedWords = 0, totalWords = 0, learnedPercent = 0)),
+        )
     }
 
     @Test
@@ -237,6 +255,13 @@ class TelegramTest {
             val (name, value) = parameter.split("=", limit = 2)
             name to URLDecoder.decode(value, StandardCharsets.UTF_8)
         }
+
+    private fun createTrainer(content: String): LearnWordsTrainer {
+        val file = kotlin.io.path.createTempFile(prefix = "telegram-dictionary-", suffix = ".txt")
+            .toFile()
+            .apply { writeText(content) }
+        return LearnWordsTrainer(file)
+    }
 
     private fun readBody(request: HttpRequest): String {
         val bodyPublisher = request.bodyPublisher().orElseThrow()


### PR DESCRIPTION
## Изменения
- LearnWordsTrainer создаётся при запуске Telegram-бота
- обработчик callback получает экземпляр тренажёра
- заглушка кнопки «Статистика» заменена вызовом trainer.getStatistics()
- пользователю отправляются количество выученных слов, общее количество и процент
- для пустого словаря отправляется понятное сообщение

## Проверка
- 19 тестов успешно пройдены
- Gradle build successful на Java 19