### PR TITLE
KTB-18 Add word learning questions to Telegram

### DIFF
--- a/src/main/kotlin/Telegram.kt
+++ b/src/main/kotlin/Telegram.kt
@@ -14,6 +14,7 @@ const val TELEGRAM_MESSAGE_MAX_LENGTH = 4096
 const val TELEGRAM_CALLBACK_DATA_MAX_BYTES = 64
 const val CALLBACK_LEARN_WORDS = "learn_words"
 const val CALLBACK_STATISTICS = "statistics"
+const val CALLBACK_DATA_ANSWER_PREFIX = "answer_"
 
 private val telegramHttpClient: HttpClient = HttpClient.newHttpClient()
 private val telegramJson = Json { ignoreUnknownKeys = true }
@@ -119,6 +120,7 @@ fun handleUpdate(
     update: TelegramUpdate,
     trainer: LearnWordsTrainer,
     messageSender: (String, Long, String, InlineKeyboardMarkup?) -> String = ::sendMessage,
+    questionSender: (String, Long, Question) -> String = ::sendQuestion,
     callbackAnswerer: (String, String) -> String = ::answerCallbackQuery,
 ) {
     if (update.message?.text != null) {
@@ -128,14 +130,43 @@ fun handleUpdate(
     update.callbackQuery?.let { callback ->
         callbackAnswerer(botToken, callback.id)
         val chatId = callback.message?.chat?.id ?: return@let
-        val responseText = when (callback.data) {
-            CALLBACK_LEARN_WORDS -> "Начинаем учить слова."
-            CALLBACK_STATISTICS -> formatStatistics(trainer.getStatistics())
-            else -> "Неизвестная команда."
+        when (callback.data) {
+            CALLBACK_LEARN_WORDS -> {
+                val question = trainer.getNextQuestion()
+                if (question == null) {
+                    messageSender(botToken, chatId, "Вы выучили все слова в базе", mainMenuKeyboard)
+                } else {
+                    questionSender(botToken, chatId, question)
+                }
+            }
+            CALLBACK_STATISTICS -> {
+                val responseText = formatStatistics(trainer.getStatistics())
+                messageSender(botToken, chatId, responseText, mainMenuKeyboard)
+            }
+            else -> messageSender(botToken, chatId, "Неизвестная команда.", mainMenuKeyboard)
         }
-        messageSender(botToken, chatId, responseText, mainMenuKeyboard)
     }
 }
+
+fun sendQuestion(botToken: String, chatId: Long, question: Question): String =
+    sendMessage(
+        botToken = botToken,
+        chatId = chatId,
+        text = question.correctWord.original,
+        replyMarkup = createQuestionKeyboard(question),
+    )
+
+fun createQuestionKeyboard(question: Question): InlineKeyboardMarkup =
+    InlineKeyboardMarkup(
+        inlineKeyboard = question.variants.mapIndexed { index, word ->
+            listOf(
+                InlineKeyboardButton(
+                    text = word.translated,
+                    callbackData = "$CALLBACK_DATA_ANSWER_PREFIX$index",
+                ),
+            )
+        },
+    )
 
 fun formatStatistics(statistics: Statistics): String =
     if (statistics.totalWords == 0) {

--- a/src/test/kotlin/TelegramTest.kt
+++ b/src/test/kotlin/TelegramTest.kt
@@ -163,6 +163,117 @@ class TelegramTest {
     }
 
     @Test
+    fun `learn words callback sends next question to source chat`() {
+        val trainer = createTrainer(
+            """
+            cat|кошка|0
+            dog|собака|0
+            house|дом|0
+            """.trimIndent(),
+        )
+        val sentQuestions = mutableListOf<Pair<Long, Question>>()
+        val update = TelegramUpdate(
+            updateId = 33,
+            callbackQuery = TelegramCallbackQuery(
+                id = "callback-33",
+                data = CALLBACK_LEARN_WORDS,
+                message = TelegramMessage(TelegramChat(999), "Выберите действие:"),
+            ),
+        )
+
+        handleUpdate(
+            botToken = "token",
+            update = update,
+            trainer = trainer,
+            questionSender = { _, chatId, question ->
+                sentQuestions += chatId to question
+                "{}"
+            },
+            callbackAnswerer = { _, _ -> "true" },
+        )
+
+        assertEquals(1, sentQuestions.size)
+        assertEquals(999L, sentQuestions.single().first)
+        assertEquals(trainer.currentQuestion, sentQuestions.single().second)
+    }
+
+    @Test
+    fun `learn words callback reports when all words are learned`() {
+        val trainer = createTrainer("cat|кошка|3")
+        val sentMessages = mutableListOf<Triple<Long, String, InlineKeyboardMarkup?>>()
+        val update = TelegramUpdate(
+            updateId = 34,
+            callbackQuery = TelegramCallbackQuery(
+                id = "callback-34",
+                data = CALLBACK_LEARN_WORDS,
+                message = TelegramMessage(TelegramChat(1000), "Выберите действие:"),
+            ),
+        )
+
+        handleUpdate(
+            botToken = "token",
+            update = update,
+            trainer = trainer,
+            messageSender = { _, chatId, text, keyboard ->
+                sentMessages += Triple(chatId, text, keyboard)
+                "{}"
+            },
+            callbackAnswerer = { _, _ -> "true" },
+        )
+
+        assertEquals(1, sentMessages.size)
+        assertEquals(1000L, sentMessages.single().first)
+        assertEquals("Вы выучили все слова в базе", sentMessages.single().second)
+        assertEquals(mainMenuKeyboard, sentMessages.single().third)
+    }
+
+    @Test
+    fun `question keyboard contains translated answers and indexed callback data`() {
+        val correctWord = Word("cat", "кошка")
+        val question = Question(
+            correctWord = correctWord,
+            variants = listOf(
+                Word("dog", "собака"),
+                correctWord,
+                Word("house", "дом"),
+            ),
+        )
+
+        val keyboard = createQuestionKeyboard(question)
+
+        assertEquals(
+            listOf(
+                InlineKeyboardButton("собака", "answer_0"),
+                InlineKeyboardButton("кошка", "answer_1"),
+                InlineKeyboardButton("дом", "answer_2"),
+            ),
+            keyboard.inlineKeyboard.flatten(),
+        )
+    }
+
+    @Test
+    fun `send question request uses english word and answer keyboard`() {
+        val correctWord = Word("cat", "кошка")
+        val question = Question(
+            correctWord = correctWord,
+            variants = listOf(correctWord, Word("dog", "собака")),
+        )
+        val request = createSendMessageRequest(
+            botToken = "token",
+            chatId = 123,
+            text = question.correctWord.original,
+            replyMarkup = createQuestionKeyboard(question),
+        )
+        val parameters = parseFormBody(readBody(request))
+
+        assertEquals("cat", parameters["text"])
+        assertEquals(
+            """{"inline_keyboard":[[{"text":"кошка","callback_data":"answer_0"}],[{"text":"собака","callback_data":"answer_1"}]]}""",
+            parameters["reply_markup"],
+        )
+    }
+
+    @Test
     fun `empty dictionary statistics are formatted for telegram`() {
         assertEquals(
             "Словарь пуст.",


### PR DESCRIPTION
## Изменения
- добавлена обработка кнопки «Учить слова» через trainer.getNextQuestion()
- при завершении обучения отправляется сообщение «Вы выучили все слова в базе»
- добавлена константа CALLBACK_DATA_ANSWER_PREFIX со значением answer_
- реализована функция sendQuestion для отправки английского слова и вариантов перевода
- варианты ответа формируются как inline-кнопки с callback_data answer_<index>

## Проверка
- 23 теста успешно пройдены
- Gradle build successful на Java 19