### PR TITLE
KTB-20 Fix bot imperfections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 .gradle-local/
 build/
+user-progress/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# LearnEnglishWordsTelegramBot
+
+Это JVM-приложение Telegram-бота, а не Android-приложение. Оно запускается на компьютере
+или сервере и не устанавливается в Android Emulator.
+
+## Запуск из Android Studio
+
+1. Откройте окно **Gradle**.
+2. Выберите `Tasks` -> `application` -> `run`.
+3. В конфигурации запуска добавьте переменную окружения:
+   `TELEGRAM_BOT_TOKEN=<токен бота>`.
+4. Запустите задачу `run`.
+
+Также бот можно запустить из терминала:
+
+```bash
+TELEGRAM_BOT_TOKEN="<токен бота>" ./gradlew run
+```
+
+Для остановки бота нажмите `Ctrl+C`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    application
     kotlin("jvm") version "2.2.0"
     kotlin("plugin.serialization") version "2.2.0"
 }
@@ -18,6 +19,11 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
 }
+
+application {
+    mainClass.set("TelegramKt")
+}
+
 kotlin {
     jvmToolchain(19)
 }

--- a/src/main/kotlin/LearnWordsTrainer.kt
+++ b/src/main/kotlin/LearnWordsTrainer.kt
@@ -77,6 +77,12 @@ class LearnWordsTrainer(
         return isCorrect
     }
 
+    fun resetProgress() {
+        dictionary.forEach { it.correctAnswersCount = 0 }
+        currentQuestion = null
+        saveDictionary()
+    }
+
     private fun loadDictionary(): List<Word> {
         if (!wordsFile.exists()) {
             println("Файл со словарем не найден. Создан новый.")

--- a/src/main/kotlin/Telegram.kt
+++ b/src/main/kotlin/Telegram.kt
@@ -86,11 +86,7 @@ val mainMenuKeyboard = InlineKeyboardMarkup(
 )
 
 fun main(args: Array<String>) {
-    require(args.isNotEmpty() && args[0].isNotBlank()) {
-        "Передайте токен Telegram-бота первым аргументом."
-    }
-
-    val botToken = args[0]
+    val botToken = resolveBotToken(args)
     val trainer = LearnWordsTrainer()
     var updateId = 0L
     while (true) {
@@ -102,6 +98,18 @@ fun main(args: Array<String>) {
         }
 
         updateId = updates.result.maxOfOrNull { it.updateId + 1 } ?: updateId
+    }
+}
+
+fun resolveBotToken(
+    args: Array<String>,
+    environment: Map<String, String> = System.getenv(),
+): String {
+    val botToken = args.firstOrNull()?.takeIf { it.isNotBlank() }
+        ?: environment["TELEGRAM_BOT_TOKEN"]?.takeIf { it.isNotBlank() }
+
+    return requireNotNull(botToken) {
+        "Передайте токен первым аргументом или задайте переменную TELEGRAM_BOT_TOKEN."
     }
 }
 

--- a/src/main/kotlin/Telegram.kt
+++ b/src/main/kotlin/Telegram.kt
@@ -2,6 +2,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.io.File
 import java.net.URI
 import java.net.URLEncoder
 import java.net.http.HttpClient
@@ -14,6 +15,7 @@ const val TELEGRAM_MESSAGE_MAX_LENGTH = 4096
 const val TELEGRAM_CALLBACK_DATA_MAX_BYTES = 64
 const val CALLBACK_LEARN_WORDS = "learn_words"
 const val CALLBACK_STATISTICS = "statistics"
+const val CALLBACK_RESET_PROGRESS = "reset_progress"
 const val CALLBACK_DATA_ANSWER_PREFIX = "answer_"
 
 private val telegramHttpClient: HttpClient = HttpClient.newHttpClient()
@@ -82,23 +84,62 @@ val mainMenuKeyboard = InlineKeyboardMarkup(
     inlineKeyboard = listOf(
         listOf(InlineKeyboardButton("Учить слова", CALLBACK_LEARN_WORDS)),
         listOf(InlineKeyboardButton("Статистика", CALLBACK_STATISTICS)),
+        listOf(InlineKeyboardButton("Сбросить прогресс", CALLBACK_RESET_PROGRESS)),
     ),
 )
 
 fun main(args: Array<String>) {
     val botToken = resolveBotToken(args)
-    val trainer = LearnWordsTrainer()
+    val trainers = mutableMapOf<Long, LearnWordsTrainer>()
     var updateId = 0L
     while (true) {
         Thread.sleep(3000)
         val updates = parseUpdates(getUpdates(botToken, updateId))
 
-        updates.result.forEach { update ->
-            handleUpdate(botToken, update, trainer)
+        updates.result.sortedBy { it.updateId }.forEach { update ->
+            handleUpdate(
+                botToken = botToken,
+                update = update,
+                trainerProvider = { chatId ->
+                    trainers.getOrPut(chatId) { createTrainerForChat(chatId) }
+                },
+            )
         }
 
         updateId = updates.result.maxOfOrNull { it.updateId + 1 } ?: updateId
     }
+}
+
+fun createTrainerForChat(
+    chatId: Long,
+    sourceDictionary: File = File("words.txt"),
+    progressDirectory: File = File("user-progress"),
+): LearnWordsTrainer {
+    val progressFile = File(progressDirectory, "$chatId.txt")
+    if (!progressFile.exists()) {
+        progressFile.parentFile?.mkdirs()
+        val initialDictionary = if (sourceDictionary.exists()) {
+            sourceDictionary.readLines().mapNotNull { line ->
+                val parts = line.split("|").map(String::trim)
+                val original = parts.getOrNull(0).orEmpty()
+                val translated = parts.getOrNull(1).orEmpty()
+                if (original.isBlank() || translated.isBlank()) {
+                    null
+                } else {
+                    "$original|$translated|0"
+                }
+            }
+        } else {
+            emptyList()
+        }
+        progressFile.writeText(
+            initialDictionary.joinToString(
+                separator = "\n",
+                postfix = if (initialDictionary.isEmpty()) "" else "\n",
+            ),
+        )
+    }
+    return LearnWordsTrainer(progressFile)
 }
 
 fun resolveBotToken(
@@ -126,33 +167,92 @@ fun getUpdates(botToken: String, updateId: Long): String {
 fun handleUpdate(
     botToken: String,
     update: TelegramUpdate,
-    trainer: LearnWordsTrainer,
+    trainerProvider: (Long) -> LearnWordsTrainer,
     messageSender: (String, Long, String, InlineKeyboardMarkup?) -> String = ::sendMessage,
     questionSender: (String, Long, Question) -> String = ::sendQuestion,
     callbackAnswerer: (String, String) -> String = ::answerCallbackQuery,
 ) {
+    val chatId = update.message?.chat?.id ?: update.callbackQuery?.message?.chat?.id ?: return
+    val trainer = trainerProvider(chatId)
+
     if (update.message?.text != null) {
-        messageSender(botToken, update.message.chat.id, "Выберите действие:", mainMenuKeyboard)
+        messageSender(botToken, chatId, "Выберите действие:", mainMenuKeyboard)
     }
 
     update.callbackQuery?.let { callback ->
         callbackAnswerer(botToken, callback.id)
-        val chatId = callback.message?.chat?.id ?: return@let
-        when (callback.data) {
-            CALLBACK_LEARN_WORDS -> {
-                val question = trainer.getNextQuestion()
-                if (question == null) {
-                    messageSender(botToken, chatId, "Вы выучили все слова в базе", mainMenuKeyboard)
-                } else {
-                    questionSender(botToken, chatId, question)
-                }
-            }
-            CALLBACK_STATISTICS -> {
+        when {
+            callback.data == CALLBACK_LEARN_WORDS ->
+                sendNextQuestion(botToken, chatId, trainer, messageSender, questionSender)
+
+            callback.data == CALLBACK_STATISTICS -> {
                 val responseText = formatStatistics(trainer.getStatistics())
                 messageSender(botToken, chatId, responseText, mainMenuKeyboard)
             }
-            else -> messageSender(botToken, chatId, "Неизвестная команда.", mainMenuKeyboard)
+
+            callback.data == CALLBACK_RESET_PROGRESS -> {
+                trainer.resetProgress()
+                messageSender(botToken, chatId, "Прогресс сброшен.", mainMenuKeyboard)
+            }
+
+            callback.data?.startsWith(CALLBACK_DATA_ANSWER_PREFIX) == true ->
+                handleAnswer(
+                    botToken = botToken,
+                    chatId = chatId,
+                    callbackData = callback.data,
+                    trainer = trainer,
+                    messageSender = messageSender,
+                    questionSender = questionSender,
+                )
+
+            else ->
+                messageSender(botToken, chatId, "Неизвестная команда.", mainMenuKeyboard)
         }
+    }
+}
+
+private fun handleAnswer(
+    botToken: String,
+    chatId: Long,
+    callbackData: String,
+    trainer: LearnWordsTrainer,
+    messageSender: (String, Long, String, InlineKeyboardMarkup?) -> String,
+    questionSender: (String, Long, Question) -> String,
+) {
+    val answerIndex = callbackData.substringAfter(CALLBACK_DATA_ANSWER_PREFIX).toIntOrNull()
+    val question = trainer.currentQuestion
+    if (answerIndex == null || question == null) {
+        messageSender(
+            botToken,
+            chatId,
+            "Сначала выберите «Учить слова».",
+            mainMenuKeyboard,
+        )
+        return
+    }
+
+    val isCorrect = trainer.checkAnswer(answerIndex + 1)
+    val resultText = if (isCorrect) {
+        "Правильно!"
+    } else {
+        "Неправильно! ${question.correctWord.original} - ${question.correctWord.translated}"
+    }
+    messageSender(botToken, chatId, resultText, null)
+    sendNextQuestion(botToken, chatId, trainer, messageSender, questionSender)
+}
+
+private fun sendNextQuestion(
+    botToken: String,
+    chatId: Long,
+    trainer: LearnWordsTrainer,
+    messageSender: (String, Long, String, InlineKeyboardMarkup?) -> String,
+    questionSender: (String, Long, Question) -> String,
+) {
+    val question = trainer.getNextQuestion()
+    if (question == null) {
+        messageSender(botToken, chatId, "Вы выучили все слова в базе", mainMenuKeyboard)
+    } else {
+        questionSender(botToken, chatId, question)
     }
 }
 

--- a/src/test/kotlin/LearnWordsTrainerTest.kt
+++ b/src/test/kotlin/LearnWordsTrainerTest.kt
@@ -97,6 +97,30 @@ class LearnWordsTrainerTest {
         assertNull(trainer.currentQuestion)
     }
 
+    @Test
+    fun `reset progress clears answers and current question`() {
+        val file = createDictionaryFile(
+            """
+            cat|кошка|3
+            dog|собака|2
+            """.trimIndent(),
+        )
+        val trainer = LearnWordsTrainer(file, random = Random(1))
+        trainer.getNextQuestion()
+
+        trainer.resetProgress()
+
+        assertEquals(listOf(0, 0), trainer.dictionary.map { it.correctAnswersCount })
+        assertNull(trainer.currentQuestion)
+        assertEquals(
+            """
+            cat|кошка|0
+            dog|собака|0
+            """.trimIndent(),
+            file.readText().trim(),
+        )
+    }
+
     private fun createTrainer(content: String): LearnWordsTrainer =
         LearnWordsTrainer(createDictionaryFile(content), random = Random(1))
 

--- a/src/test/kotlin/TelegramTest.kt
+++ b/src/test/kotlin/TelegramTest.kt
@@ -12,6 +12,22 @@ import kotlin.test.assertTrue
 
 class TelegramTest {
     @Test
+    fun `bot token can be read from argument or environment`() {
+        assertEquals("argument-token", resolveBotToken(arrayOf("argument-token"), emptyMap()))
+        assertEquals(
+            "environment-token",
+            resolveBotToken(emptyArray(), mapOf("TELEGRAM_BOT_TOKEN" to "environment-token")),
+        )
+    }
+
+    @Test
+    fun `bot token is required`() {
+        assertFailsWith<IllegalArgumentException> {
+            resolveBotToken(emptyArray(), emptyMap())
+        }
+    }
+
+    @Test
     fun `updates preserve chat id for every message`() {
         val response = parseUpdates(
             """

--- a/src/test/kotlin/TelegramTest.kt
+++ b/src/test/kotlin/TelegramTest.kt
@@ -1,12 +1,14 @@
+import java.io.File
+import java.net.URLDecoder
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.ByteBuffer
-import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.Flow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -135,7 +137,7 @@ class TelegramTest {
         handleUpdate(
             botToken = "token",
             update = update,
-            trainer = trainer,
+            trainerProvider = { trainer },
             messageSender = { _, chatId, text, keyboard ->
                 sentMessages += Triple(chatId, text, keyboard)
                 "{}"
@@ -165,7 +167,7 @@ class TelegramTest {
         handleUpdate(
             botToken = "token",
             update = update,
-            trainer = trainer,
+            trainerProvider = { trainer },
             messageSender = { _, chatId, text, keyboard ->
                 sentMessages += Triple(chatId, text, keyboard)
                 "{}"
@@ -200,7 +202,7 @@ class TelegramTest {
         handleUpdate(
             botToken = "token",
             update = update,
-            trainer = trainer,
+            trainerProvider = { trainer },
             questionSender = { _, chatId, question ->
                 sentQuestions += chatId to question
                 "{}"
@@ -229,7 +231,7 @@ class TelegramTest {
         handleUpdate(
             botToken = "token",
             update = update,
-            trainer = trainer,
+            trainerProvider = { trainer },
             messageSender = { _, chatId, text, keyboard ->
                 sentMessages += Triple(chatId, text, keyboard)
                 "{}"
@@ -241,6 +243,172 @@ class TelegramTest {
         assertEquals(1000L, sentMessages.single().first)
         assertEquals("Вы выучили все слова в базе", sentMessages.single().second)
         assertEquals(mainMenuKeyboard, sentMessages.single().third)
+    }
+
+    @Test
+    fun `answer callback checks answer and sends next question`() {
+        val trainer = createTrainer(
+            """
+            cat|кошка|0
+            dog|собака|0
+            """.trimIndent(),
+        )
+        val question = assertNotNull(trainer.getNextQuestion())
+        val correctIndex = question.variants.indexOf(question.correctWord)
+        val sentMessages = mutableListOf<String>()
+        val sentQuestions = mutableListOf<Question>()
+        val update = TelegramUpdate(
+            updateId = 35,
+            callbackQuery = TelegramCallbackQuery(
+                id = "callback-35",
+                data = "$CALLBACK_DATA_ANSWER_PREFIX$correctIndex",
+                message = TelegramMessage(TelegramChat(1001), question.correctWord.original),
+            ),
+        )
+
+        handleUpdate(
+            botToken = "token",
+            update = update,
+            trainerProvider = { trainer },
+            messageSender = { _, _, text, _ ->
+                sentMessages += text
+                "{}"
+            },
+            questionSender = { _, _, nextQuestion ->
+                sentQuestions += nextQuestion
+                "{}"
+            },
+            callbackAnswerer = { _, _ -> "true" },
+        )
+
+        assertEquals(listOf("Правильно!"), sentMessages)
+        assertEquals(1, question.correctWord.correctAnswersCount)
+        assertEquals(1, sentQuestions.size)
+        assertEquals(trainer.currentQuestion, sentQuestions.single())
+    }
+
+    @Test
+    fun `incorrect answer shows correct translation and continues learning`() {
+        val trainer = createTrainer(
+            """
+            cat|кошка|0
+            dog|собака|0
+            """.trimIndent(),
+        )
+        val question = assertNotNull(trainer.getNextQuestion())
+        val incorrectIndex = question.variants.indexOfFirst { it != question.correctWord }
+        val sentMessages = mutableListOf<String>()
+        val sentQuestions = mutableListOf<Question>()
+
+        handleUpdate(
+            botToken = "token",
+            update = TelegramUpdate(
+                updateId = 36,
+                callbackQuery = TelegramCallbackQuery(
+                    id = "callback-36",
+                    data = "$CALLBACK_DATA_ANSWER_PREFIX$incorrectIndex",
+                    message = TelegramMessage(TelegramChat(1002), question.correctWord.original),
+                ),
+            ),
+            trainerProvider = { trainer },
+            messageSender = { _, _, text, _ ->
+                sentMessages += text
+                "{}"
+            },
+            questionSender = { _, _, nextQuestion ->
+                sentQuestions += nextQuestion
+                "{}"
+            },
+            callbackAnswerer = { _, _ -> "true" },
+        )
+
+        assertEquals(
+            listOf("Неправильно! ${question.correctWord.original} - ${question.correctWord.translated}"),
+            sentMessages,
+        )
+        assertEquals(0, question.correctWord.correctAnswersCount)
+        assertEquals(1, sentQuestions.size)
+    }
+
+    @Test
+    fun `answer without active question returns to menu`() {
+        val trainer = createTrainer("cat|кошка|0")
+        val sentMessages = mutableListOf<Triple<Long, String, InlineKeyboardMarkup?>>()
+
+        handleUpdate(
+            botToken = "token",
+            update = TelegramUpdate(
+                updateId = 37,
+                callbackQuery = TelegramCallbackQuery(
+                    id = "callback-37",
+                    data = "${CALLBACK_DATA_ANSWER_PREFIX}0",
+                    message = TelegramMessage(TelegramChat(1003), "old question"),
+                ),
+            ),
+            trainerProvider = { trainer },
+            messageSender = { _, chatId, text, keyboard ->
+                sentMessages += Triple(chatId, text, keyboard)
+                "{}"
+            },
+            callbackAnswerer = { _, _ -> "true" },
+        )
+
+        assertEquals(1, sentMessages.size)
+        assertEquals(1003L, sentMessages.single().first)
+        assertEquals("Сначала выберите «Учить слова».", sentMessages.single().second)
+        assertEquals(mainMenuKeyboard, sentMessages.single().third)
+    }
+
+    @Test
+    fun `reset progress callback clears only current chat trainer`() {
+        val trainer = createTrainer("cat|кошка|3")
+        val sentMessages = mutableListOf<Triple<Long, String, InlineKeyboardMarkup?>>()
+
+        handleUpdate(
+            botToken = "token",
+            update = TelegramUpdate(
+                updateId = 38,
+                callbackQuery = TelegramCallbackQuery(
+                    id = "callback-38",
+                    data = CALLBACK_RESET_PROGRESS,
+                    message = TelegramMessage(TelegramChat(1004), "Выберите действие:"),
+                ),
+            ),
+            trainerProvider = { trainer },
+            messageSender = { _, chatId, text, keyboard ->
+                sentMessages += Triple(chatId, text, keyboard)
+                "{}"
+            },
+            callbackAnswerer = { _, _ -> "true" },
+        )
+
+        assertEquals(0, trainer.dictionary.single().correctAnswersCount)
+        assertEquals(1, sentMessages.size)
+        assertEquals(1004L, sentMessages.single().first)
+        assertEquals("Прогресс сброшен.", sentMessages.single().second)
+        assertEquals(mainMenuKeyboard, sentMessages.single().third)
+    }
+
+    @Test
+    fun `chat trainers have independent persistent progress`() {
+        val root = kotlin.io.path.createTempDirectory("telegram-progress-").toFile()
+        val source = File(root, "words.txt").apply { writeText("cat|кошка|2\n") }
+        val progressDirectory = File(root, "users")
+        val firstTrainer = createTrainerForChat(111, source, progressDirectory)
+        val secondTrainer = createTrainerForChat(222, source, progressDirectory)
+
+        repeat(3) {
+            val question = assertNotNull(firstTrainer.getNextQuestion())
+            assertTrue(firstTrainer.checkAnswer(question.variants.indexOf(question.correctWord) + 1))
+        }
+
+        assertEquals(Statistics(1, 1, 100), firstTrainer.getStatistics())
+        assertEquals(Statistics(0, 1, 0), secondTrainer.getStatistics())
+        assertEquals(
+            Statistics(1, 1, 100),
+            createTrainerForChat(111, source, progressDirectory).getStatistics(),
+        )
+        assertEquals("cat|кошка|2", source.readText().trim())
     }
 
     @Test
@@ -337,7 +505,7 @@ class TelegramTest {
         assertEquals("123", parameters["chat_id"])
         assertEquals("Меню", parameters["text"])
         assertEquals(
-            """{"inline_keyboard":[[{"text":"Учить слова","callback_data":"learn_words"}],[{"text":"Статистика","callback_data":"statistics"}]]}""",
+            """{"inline_keyboard":[[{"text":"Учить слова","callback_data":"learn_words"}],[{"text":"Статистика","callback_data":"statistics"}],[{"text":"Сбросить прогресс","callback_data":"reset_progress"}]]}""",
             parameters["reply_markup"],
         )
     }


### PR DESCRIPTION
## Исправления после тестирования
- отдельный LearnWordsTrainer и файл прогресса для каждого chat_id
- исходный words.txt используется как неизменяемый шаблон словаря
- добавлена обработка callback answer_<index>
- после ответа показывается результат и автоматически отправляется следующий вопрос
- устаревшие кнопки ответа безопасно возвращают пользователя в меню
- добавлена кнопка «Сбросить прогресс» и сохранение сброса в файл
- апдейты обрабатываются по возрастанию update_id
- добавлен корректный JVM-запуск бота через Gradle вместо Android Emulator

## Проверка
- 31 тест успешно пройден
- проверены правильный и неправильный ответы
- проверена независимость и сохранение прогресса двух чатов
- Gradle build successful на Java 19