### PR TITLE
KTB-24 Add Yandex Dictionary integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,38 @@ TELEGRAM_BOT_TOKEN="<токен бота>" ./gradlew run
 ```
 
 Для остановки бота нажмите `Ctrl+C`.
+
+## Онлайн-словарь Yandex Dictionary
+
+Для новых пользователей бот может брать слова из Yandex Dictionary вместо локального
+`words.txt`. API-ключ нельзя хранить в открытом коде, поэтому задайте его через
+переменную окружения:
+
+```bash
+TELEGRAM_BOT_TOKEN="<токен бота>" \
+YANDEX_DICTIONARY_API_KEY="<ключ Yandex Dictionary>" \
+YANDEX_DICTIONARY_WORDS="cat,dog,house,book" \
+./gradlew run
+```
+
+Для локального запуска можно создать файл `local.properties` в корне проекта:
+
+```properties
+YANDEX_DICTIONARY_API_KEY=<ключ Yandex Dictionary>
+YANDEX_DICTIONARY_WORDS=cat,dog,house,book
+```
+
+Файл `local.properties` добавлен в `.gitignore`, поэтому он не должен попадать в
+публичный репозиторий.
+
+Дополнительные настройки:
+
+- `YANDEX_DICTIONARY_API_KEY` - ключ Yandex Dictionary.
+- `YANDEX_DICTIONARY_WORDS` - список английских слов через запятую, точку с запятой
+  или перенос строки. Если не указать, используется встроенный стартовый список.
+- `YANDEX_DICTIONARY_LANG` - направление перевода. По умолчанию используется `en-ru`.
+
+Если не задавать `YANDEX_DICTIONARY_API_KEY` ни в окружении, ни в `local.properties`,
+бот продолжит использовать локальный `words.txt`. Прогресс пользователей по-прежнему
+хранится отдельно в `user-progress/<chat_id>.txt`, поэтому разные чаты не
+перезаписывают результаты друг друга.

--- a/src/main/kotlin/Telegram.kt
+++ b/src/main/kotlin/Telegram.kt
@@ -114,29 +114,21 @@ fun createTrainerForChat(
     chatId: Long,
     sourceDictionary: File = File("words.txt"),
     progressDirectory: File = File("user-progress"),
+    environment: Map<String, String> = System.getenv(),
+    localPropertiesFile: File = File(LOCAL_PROPERTIES_FILE_NAME),
+    initialDictionaryLoader: () -> List<Word> = {
+        loadInitialDictionary(sourceDictionary, environment, localPropertiesFile)
+    },
 ): LearnWordsTrainer {
     val progressFile = File(progressDirectory, "$chatId.txt")
     if (!progressFile.exists()) {
         progressFile.parentFile?.mkdirs()
-        val initialDictionary = if (sourceDictionary.exists()) {
-            sourceDictionary.readLines().mapNotNull { line ->
-                val parts = line.split("|").map(String::trim)
-                val original = parts.getOrNull(0).orEmpty()
-                val translated = parts.getOrNull(1).orEmpty()
-                if (original.isBlank() || translated.isBlank()) {
-                    null
-                } else {
-                    "$original|$translated|0"
-                }
-            }
-        } else {
-            emptyList()
-        }
+        val initialDictionary = initialDictionaryLoader()
         progressFile.writeText(
             initialDictionary.joinToString(
                 separator = "\n",
                 postfix = if (initialDictionary.isEmpty()) "" else "\n",
-            ),
+            ) { "${it.original}|${it.translated}|${it.correctAnswersCount}" },
         )
     }
     return LearnWordsTrainer(progressFile)

--- a/src/main/kotlin/YandexDictionary.kt
+++ b/src/main/kotlin/YandexDictionary.kt
@@ -1,0 +1,174 @@
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.util.Properties
+
+const val YANDEX_DICTIONARY_BASE_URL = "https://dictionary.yandex.net/api/v1/dicservice.json"
+const val YANDEX_DICTIONARY_API_KEY_ENV = "YANDEX_DICTIONARY_API_KEY"
+const val YANDEX_DICTIONARY_LANG_ENV = "YANDEX_DICTIONARY_LANG"
+const val YANDEX_DICTIONARY_WORDS_ENV = "YANDEX_DICTIONARY_WORDS"
+const val YANDEX_DICTIONARY_DEFAULT_LANG = "en-ru"
+const val LOCAL_PROPERTIES_FILE_NAME = "local.properties"
+
+val defaultYandexDictionaryWords = listOf(
+    "cat",
+    "dog",
+    "house",
+    "book",
+    "water",
+    "sun",
+    "work",
+    "family",
+    "school",
+    "friend",
+)
+
+@Serializable
+data class YandexLookupResponse(
+    val def: List<YandexDefinition> = emptyList(),
+)
+
+@Serializable
+data class YandexDefinition(
+    val tr: List<YandexTranslation> = emptyList(),
+)
+
+@Serializable
+data class YandexTranslation(
+    val text: String,
+)
+
+@Serializable
+data class YandexErrorResponse(
+    val code: Int? = null,
+    val message: String? = null,
+)
+
+class YandexDictionaryClient(
+    private val apiKey: String,
+    private val lang: String = YANDEX_DICTIONARY_DEFAULT_LANG,
+    private val baseUrl: String = YANDEX_DICTIONARY_BASE_URL,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+    private val responseLoader: (HttpRequest) -> String = ::loadResponseBody,
+) {
+    init {
+        require(apiKey.isNotBlank()) { "API-ключ Yandex Dictionary не должен быть пустым." }
+        require(lang.isNotBlank()) { "Направление перевода не должно быть пустым." }
+    }
+
+    fun loadWords(words: List<String>): List<Word> =
+        words.mapNotNull { lookup(it) }
+
+    fun lookup(word: String): Word? {
+        val normalizedWord = word.trim()
+        if (normalizedWord.isBlank()) {
+            return null
+        }
+
+        val responseBody = responseLoader(createLookupRequest(normalizedWord))
+        val error = json.decodeFromString<YandexErrorResponse>(responseBody)
+        if (error.code != null && error.code != 200) {
+            error("Yandex Dictionary API вернул ошибку (${error.code}: ${error.message.orEmpty()}).")
+        }
+
+        val response = json.decodeFromString<YandexLookupResponse>(responseBody)
+        val translated = response.def
+            .asSequence()
+            .flatMap { it.tr.asSequence() }
+            .map { it.text.trim() }
+            .firstOrNull { it.isNotBlank() }
+
+        return translated?.let { Word(normalizedWord, it) }
+    }
+
+    fun createLookupRequest(word: String): HttpRequest =
+        HttpRequest.newBuilder()
+            .uri(
+                URI.create(
+                    "$baseUrl/lookup?key=${urlEncode(apiKey)}&lang=${urlEncode(lang)}&text=${urlEncode(word)}",
+                ),
+            )
+            .build()
+}
+
+fun loadInitialDictionary(
+    sourceDictionary: File,
+    environment: Map<String, String> = System.getenv(),
+    localPropertiesFile: File = File(LOCAL_PROPERTIES_FILE_NAME),
+    yandexDictionaryLoader: (String, String, List<String>) -> List<Word> = { apiKey, lang, words ->
+        YandexDictionaryClient(apiKey = apiKey, lang = lang).loadWords(words)
+    },
+): List<Word> {
+    val localProperties = loadLocalProperties(localPropertiesFile)
+    val apiKey = findConfigValue(YANDEX_DICTIONARY_API_KEY_ENV, environment, localProperties)
+    if (apiKey != null) {
+        val lang = findConfigValue(YANDEX_DICTIONARY_LANG_ENV, environment, localProperties)
+            ?: YANDEX_DICTIONARY_DEFAULT_LANG
+        val words = parseYandexDictionaryWords(
+            findConfigValue(YANDEX_DICTIONARY_WORDS_ENV, environment, localProperties),
+        )
+            .ifEmpty { defaultYandexDictionaryWords }
+
+        return yandexDictionaryLoader(apiKey, lang, words)
+    }
+
+    return loadDictionaryFromFile(sourceDictionary)
+}
+
+fun loadLocalProperties(localPropertiesFile: File): Map<String, String> {
+    if (!localPropertiesFile.exists()) {
+        return emptyMap()
+    }
+
+    val properties = Properties()
+    localPropertiesFile.inputStream().use(properties::load)
+    return properties.entries.associate { (key, value) -> key.toString() to value.toString() }
+}
+
+fun loadDictionaryFromFile(sourceDictionary: File): List<Word> {
+    if (!sourceDictionary.exists()) {
+        return emptyList()
+    }
+
+    return sourceDictionary.readLines().mapNotNull { line ->
+        val parts = line.split("|").map(String::trim)
+        val original = parts.getOrNull(0).orEmpty()
+        val translated = parts.getOrNull(1).orEmpty()
+        if (original.isBlank() || translated.isBlank()) {
+            null
+        } else {
+            Word(original, translated)
+        }
+    }
+}
+
+fun parseYandexDictionaryWords(rawWords: String?): List<String> =
+    rawWords
+        ?.split(",", ";", "\n")
+        ?.map(String::trim)
+        ?.filter(String::isNotBlank)
+        ?.distinct()
+        .orEmpty()
+
+private fun findConfigValue(
+    key: String,
+    environment: Map<String, String>,
+    localProperties: Map<String, String>,
+): String? =
+    environment[key]?.takeIf { it.isNotBlank() }
+        ?: localProperties[key]?.takeIf { it.isNotBlank() }
+
+private fun loadResponseBody(request: HttpRequest): String {
+    val response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString())
+    return response.body()
+}
+
+private fun urlEncode(value: String): String =
+    URLEncoder.encode(value, StandardCharsets.UTF_8)

--- a/src/test/kotlin/TelegramTest.kt
+++ b/src/test/kotlin/TelegramTest.kt
@@ -394,8 +394,9 @@ class TelegramTest {
         val root = kotlin.io.path.createTempDirectory("telegram-progress-").toFile()
         val source = File(root, "words.txt").apply { writeText("cat|кошка|2\n") }
         val progressDirectory = File(root, "users")
-        val firstTrainer = createTrainerForChat(111, source, progressDirectory)
-        val secondTrainer = createTrainerForChat(222, source, progressDirectory)
+        val localPropertiesFile = File(root, "missing.properties")
+        val firstTrainer = createTrainerForChat(111, source, progressDirectory, localPropertiesFile = localPropertiesFile)
+        val secondTrainer = createTrainerForChat(222, source, progressDirectory, localPropertiesFile = localPropertiesFile)
 
         repeat(3) {
             val question = assertNotNull(firstTrainer.getNextQuestion())
@@ -406,9 +407,34 @@ class TelegramTest {
         assertEquals(Statistics(0, 1, 0), secondTrainer.getStatistics())
         assertEquals(
             Statistics(1, 1, 100),
-            createTrainerForChat(111, source, progressDirectory).getStatistics(),
+            createTrainerForChat(111, source, progressDirectory, localPropertiesFile = localPropertiesFile).getStatistics(),
         )
         assertEquals("cat|кошка|2", source.readText().trim())
+    }
+
+    @Test
+    fun `chat trainer can initialize progress from online dictionary loader`() {
+        val root = kotlin.io.path.createTempDirectory("telegram-online-dictionary-").toFile()
+        val progressDirectory = File(root, "users")
+
+        val trainer = createTrainerForChat(
+            chatId = 333,
+            sourceDictionary = File(root, "missing.txt"),
+            progressDirectory = progressDirectory,
+            environment = emptyMap(),
+            initialDictionaryLoader = {
+                listOf(Word("cat", "кошка"), Word("dog", "собака"))
+            },
+        )
+
+        assertEquals(Statistics(0, 2, 0), trainer.getStatistics())
+        assertEquals(
+            """
+            cat|кошка|0
+            dog|собака|0
+            """.trimIndent(),
+            File(progressDirectory, "333.txt").readText().trim(),
+        )
     }
 
     @Test

--- a/src/test/kotlin/YandexDictionaryTest.kt
+++ b/src/test/kotlin/YandexDictionaryTest.kt
@@ -1,0 +1,154 @@
+import java.io.File
+import java.net.http.HttpRequest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class YandexDictionaryTest {
+    @Test
+    fun `parse yandex dictionary words supports separators and removes duplicates`() {
+        assertEquals(
+            listOf("cat", "dog", "house", "sun"),
+            parseYandexDictionaryWords(" cat, dog;house\ncat\n sun "),
+        )
+    }
+
+    @Test
+    fun `parse yandex dictionary words returns empty list for blank input`() {
+        assertTrue(parseYandexDictionaryWords(null).isEmpty())
+        assertTrue(parseYandexDictionaryWords(" , ; \n ").isEmpty())
+    }
+
+    @Test
+    fun `yandex lookup request encodes query parameters and returns first translation`() {
+        var request: HttpRequest? = null
+        val client = YandexDictionaryClient(
+            apiKey = "key 1",
+            responseLoader = {
+                request = it
+                """{"def":[{"tr":[{"text":"кошка"},{"text":"кот"}]}]}"""
+            },
+        )
+
+        assertEquals(Word("cat", "кошка"), client.lookup("cat"))
+        assertEquals(
+            "https://dictionary.yandex.net/api/v1/dicservice.json/lookup?key=key+1&lang=en-ru&text=cat",
+            request?.uri().toString(),
+        )
+    }
+
+    @Test
+    fun `yandex lookup accepts successful response with code 200`() {
+        val client = YandexDictionaryClient(
+            apiKey = "key",
+            responseLoader = {
+                """{"head":{},"def":[{"text":"cat","tr":[{"text":"кошка"}]}],"nmt_code":1,"code":200}"""
+            },
+        )
+
+        assertEquals(Word("cat", "кошка"), client.lookup("cat"))
+    }
+
+    @Test
+    fun `yandex lookup returns null when translation is missing`() {
+        val client = YandexDictionaryClient(
+            apiKey = "key",
+            responseLoader = { """{"def":[]}""" },
+        )
+
+        assertNull(client.lookup("cat"))
+        assertNull(client.lookup(" "))
+    }
+
+    @Test
+    fun `yandex lookup reports api errors`() {
+        val client = YandexDictionaryClient(
+            apiKey = "key",
+            responseLoader = { """{"code":401,"message":"Invalid key"}""" },
+        )
+
+        val error = assertFailsWith<IllegalStateException> {
+            client.lookup("cat")
+        }
+        assertEquals("Yandex Dictionary API вернул ошибку (401: Invalid key).", error.message)
+    }
+
+    @Test
+    fun `initial dictionary prefers yandex when api key is configured`() {
+        val sourceDictionary = createDictionaryFile("local|локальный|0")
+
+        val initialDictionary = loadInitialDictionary(
+            sourceDictionary = sourceDictionary,
+            environment = mapOf(
+                YANDEX_DICTIONARY_API_KEY_ENV to "api-key",
+                YANDEX_DICTIONARY_LANG_ENV to "en-ru",
+                YANDEX_DICTIONARY_WORDS_ENV to "cat,dog",
+            ),
+            yandexDictionaryLoader = { apiKey, lang, words ->
+                assertEquals("api-key", apiKey)
+                assertEquals("en-ru", lang)
+                assertEquals(listOf("cat", "dog"), words)
+                listOf(Word("cat", "кошка"), Word("dog", "собака"))
+            },
+        )
+
+        assertEquals(listOf(Word("cat", "кошка"), Word("dog", "собака")), initialDictionary)
+    }
+
+    @Test
+    fun `initial dictionary uses local properties api key when environment key is absent`() {
+        val sourceDictionary = createDictionaryFile("local|локальный|0")
+        val localProperties = createPropertiesFile(
+            """
+            $YANDEX_DICTIONARY_API_KEY_ENV=local-api-key
+            $YANDEX_DICTIONARY_WORDS_ENV=cat
+            """.trimIndent(),
+        )
+
+        val initialDictionary = loadInitialDictionary(
+            sourceDictionary = sourceDictionary,
+            environment = emptyMap(),
+            localPropertiesFile = localProperties,
+            yandexDictionaryLoader = { apiKey, lang, words ->
+                assertEquals("local-api-key", apiKey)
+                assertEquals(YANDEX_DICTIONARY_DEFAULT_LANG, lang)
+                assertEquals(listOf("cat"), words)
+                listOf(Word("cat", "кошка"))
+            },
+        )
+
+        assertEquals(listOf(Word("cat", "кошка")), initialDictionary)
+    }
+
+    @Test
+    fun `initial dictionary falls back to local file without yandex api key`() {
+        val sourceDictionary = createDictionaryFile(
+            """
+            cat|кошка|3
+            dog|собака|0
+            broken
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            listOf(Word("cat", "кошка"), Word("dog", "собака")),
+            loadInitialDictionary(
+                sourceDictionary = sourceDictionary,
+                environment = emptyMap(),
+                localPropertiesFile = File(sourceDictionary.parentFile, "missing.properties"),
+            ),
+        )
+    }
+
+    private fun createDictionaryFile(content: String): File =
+        kotlin.io.path.createTempFile(prefix = "yandex-dictionary-", suffix = ".txt")
+            .toFile()
+            .apply { writeText(content) }
+
+    private fun createPropertiesFile(content: String): File =
+        kotlin.io.path.createTempFile(prefix = "local-", suffix = ".properties")
+            .toFile()
+            .apply { writeText(content) }
+}


### PR DESCRIPTION
## Summary
- add Yandex Dictionary lookup for initial user dictionaries
- read API keys from environment or local.properties instead of committing secrets
- keep words.txt fallback and per-chat progress files
- handle successful Yandex responses with code=200

## Tests
- JAVA_HOME=/Users/boss/Library/Java/JavaVirtualMachines/corretto-19.0.2/Contents/Home GRADLE_USER_HOME=.gradle-local ./gradlew test --no-daemon