### PR TITLE
KTB-28 Add language choices to bot menu

### DIFF
--- a/src/main/kotlin/Telegram.kt
+++ b/src/main/kotlin/Telegram.kt
@@ -114,7 +114,7 @@ data class InlineKeyboardMarkup(
 
 val mainMenuKeyboard = InlineKeyboardMarkup(
     inlineKeyboard = listOf(
-        listOf(InlineKeyboardButton("Учить слова", CALLBACK_LEARN_WORDS)),
+        listOf(InlineKeyboardButton("Учиться", CALLBACK_LEARN_WORDS)),
         listOf(InlineKeyboardButton("Статистика", CALLBACK_STATISTICS)),
         listOf(
             InlineKeyboardButton("Английский", CALLBACK_LANGUAGE_ENGLISH),

--- a/src/main/kotlin/Telegram.kt
+++ b/src/main/kotlin/Telegram.kt
@@ -116,11 +116,9 @@ val mainMenuKeyboard = InlineKeyboardMarkup(
     inlineKeyboard = listOf(
         listOf(InlineKeyboardButton("Учиться", CALLBACK_LEARN_WORDS)),
         listOf(InlineKeyboardButton("Статистика", CALLBACK_STATISTICS)),
-        listOf(
-            InlineKeyboardButton("Английский", CALLBACK_LANGUAGE_ENGLISH),
-            InlineKeyboardButton("Иврит", CALLBACK_LANGUAGE_HEBREW),
-            InlineKeyboardButton("Сербский", CALLBACK_LANGUAGE_SERBIAN),
-        ),
+        listOf(InlineKeyboardButton("1. Английский", CALLBACK_LANGUAGE_ENGLISH)),
+        listOf(InlineKeyboardButton("2. Иврит", CALLBACK_LANGUAGE_HEBREW)),
+        listOf(InlineKeyboardButton("3. Сербский", CALLBACK_LANGUAGE_SERBIAN)),
         listOf(InlineKeyboardButton("Сбросить прогресс", CALLBACK_RESET_PROGRESS)),
     ),
 )

--- a/src/main/kotlin/Telegram.kt
+++ b/src/main/kotlin/Telegram.kt
@@ -17,6 +17,9 @@ const val TELEGRAM_DISABLE_NOTIFICATION = true
 const val CALLBACK_LEARN_WORDS = "learn_words"
 const val CALLBACK_STATISTICS = "statistics"
 const val CALLBACK_RESET_PROGRESS = "reset_progress"
+const val CALLBACK_LANGUAGE_ENGLISH = "language_english"
+const val CALLBACK_LANGUAGE_HEBREW = "language_hebrew"
+const val CALLBACK_LANGUAGE_SERBIAN = "language_serbian"
 const val CALLBACK_DATA_ANSWER_PREFIX = "answer_"
 const val CORRECT_ANSWER_EMOJI = "😊"
 const val INCORRECT_ANSWER_EMOJI = "😢"
@@ -113,8 +116,19 @@ val mainMenuKeyboard = InlineKeyboardMarkup(
     inlineKeyboard = listOf(
         listOf(InlineKeyboardButton("Учить слова", CALLBACK_LEARN_WORDS)),
         listOf(InlineKeyboardButton("Статистика", CALLBACK_STATISTICS)),
+        listOf(
+            InlineKeyboardButton("Английский", CALLBACK_LANGUAGE_ENGLISH),
+            InlineKeyboardButton("Иврит", CALLBACK_LANGUAGE_HEBREW),
+            InlineKeyboardButton("Сербский", CALLBACK_LANGUAGE_SERBIAN),
+        ),
         listOf(InlineKeyboardButton("Сбросить прогресс", CALLBACK_RESET_PROGRESS)),
     ),
+)
+
+val languageNamesByCallback = mapOf(
+    CALLBACK_LANGUAGE_ENGLISH to "Английский",
+    CALLBACK_LANGUAGE_HEBREW to "Иврит",
+    CALLBACK_LANGUAGE_SERBIAN to "Сербский",
 )
 
 val botMenuCommands = listOf(
@@ -271,6 +285,16 @@ fun handleUpdate(
             callback.data == CALLBACK_RESET_PROGRESS -> {
                 trainer.resetProgress()
                 messageSender(botToken, chatId, "Прогресс сброшен.", mainMenuKeyboard)
+            }
+
+            languageNamesByCallback[callback.data] != null -> {
+                val languageName = languageNamesByCallback.getValue(callback.data.orEmpty())
+                messageSender(
+                    botToken,
+                    chatId,
+                    "Выбран язык: $languageName",
+                    mainMenuKeyboard,
+                )
             }
 
             callback.data?.startsWith(CALLBACK_DATA_ANSWER_PREFIX) == true ->

--- a/src/test/kotlin/TelegramTest.kt
+++ b/src/test/kotlin/TelegramTest.kt
@@ -620,7 +620,7 @@ class TelegramTest {
         assertEquals("Меню", parameters["text"])
         assertEquals("true", parameters["disable_notification"])
         assertEquals(
-            """{"inline_keyboard":[[{"text":"Учить слова","callback_data":"learn_words"}],[{"text":"Статистика","callback_data":"statistics"}],[{"text":"Английский","callback_data":"language_english"},{"text":"Иврит","callback_data":"language_hebrew"},{"text":"Сербский","callback_data":"language_serbian"}],[{"text":"Сбросить прогресс","callback_data":"reset_progress"}]]}""",
+            """{"inline_keyboard":[[{"text":"Учиться","callback_data":"learn_words"}],[{"text":"Статистика","callback_data":"statistics"}],[{"text":"Английский","callback_data":"language_english"},{"text":"Иврит","callback_data":"language_hebrew"},{"text":"Сербский","callback_data":"language_serbian"}],[{"text":"Сбросить прогресс","callback_data":"reset_progress"}]]}""",
             parameters["reply_markup"],
         )
     }

--- a/src/test/kotlin/TelegramTest.kt
+++ b/src/test/kotlin/TelegramTest.kt
@@ -620,7 +620,7 @@ class TelegramTest {
         assertEquals("Меню", parameters["text"])
         assertEquals("true", parameters["disable_notification"])
         assertEquals(
-            """{"inline_keyboard":[[{"text":"Учиться","callback_data":"learn_words"}],[{"text":"Статистика","callback_data":"statistics"}],[{"text":"Английский","callback_data":"language_english"},{"text":"Иврит","callback_data":"language_hebrew"},{"text":"Сербский","callback_data":"language_serbian"}],[{"text":"Сбросить прогресс","callback_data":"reset_progress"}]]}""",
+            """{"inline_keyboard":[[{"text":"Учиться","callback_data":"learn_words"}],[{"text":"Статистика","callback_data":"statistics"}],[{"text":"1. Английский","callback_data":"language_english"}],[{"text":"2. Иврит","callback_data":"language_hebrew"}],[{"text":"3. Сербский","callback_data":"language_serbian"}],[{"text":"Сбросить прогресс","callback_data":"reset_progress"}]]}""",
             parameters["reply_markup"],
         )
     }

--- a/src/test/kotlin/TelegramTest.kt
+++ b/src/test/kotlin/TelegramTest.kt
@@ -431,6 +431,35 @@ class TelegramTest {
     }
 
     @Test
+    fun `language callback confirms selected language`() {
+        val trainer = createTrainer("cat|кошка|0")
+        val sentMessages = mutableListOf<Triple<Long, String, InlineKeyboardMarkup?>>()
+
+        handleUpdate(
+            botToken = "token",
+            update = TelegramUpdate(
+                updateId = 39,
+                callbackQuery = TelegramCallbackQuery(
+                    id = "callback-39",
+                    data = CALLBACK_LANGUAGE_HEBREW,
+                    message = TelegramMessage(TelegramChat(1005), "Выберите действие:"),
+                ),
+            ),
+            trainerProvider = { trainer },
+            messageSender = { _, chatId, text, keyboard ->
+                sentMessages += Triple(chatId, text, keyboard)
+                "{}"
+            },
+            callbackAnswerer = { _, _ -> "true" },
+        )
+
+        assertEquals(1, sentMessages.size)
+        assertEquals(1005L, sentMessages.single().first)
+        assertEquals("Выбран язык: Иврит", sentMessages.single().second)
+        assertEquals(mainMenuKeyboard, sentMessages.single().third)
+    }
+
+    @Test
     fun `chat trainers have independent persistent progress`() {
         val root = kotlin.io.path.createTempDirectory("telegram-progress-").toFile()
         val progressDirectory = File(root, "users")
@@ -591,7 +620,7 @@ class TelegramTest {
         assertEquals("Меню", parameters["text"])
         assertEquals("true", parameters["disable_notification"])
         assertEquals(
-            """{"inline_keyboard":[[{"text":"Учить слова","callback_data":"learn_words"}],[{"text":"Статистика","callback_data":"statistics"}],[{"text":"Сбросить прогресс","callback_data":"reset_progress"}]]}""",
+            """{"inline_keyboard":[[{"text":"Учить слова","callback_data":"learn_words"}],[{"text":"Статистика","callback_data":"statistics"}],[{"text":"Английский","callback_data":"language_english"},{"text":"Иврит","callback_data":"language_hebrew"},{"text":"Сербский","callback_data":"language_serbian"}],[{"text":"Сбросить прогресс","callback_data":"reset_progress"}]]}""",
             parameters["reply_markup"],
         )
     }


### PR DESCRIPTION
## Summary
- add language choices to the Telegram bot main menu
- rename the learning button to "Учиться"
- show language choices vertically with numbers

## Tests
- ./gradlew test --no-daemon